### PR TITLE
Fix bug with ids in cl-transmission:transmission-set

### DIFF
--- a/src/cl-transmission.lisp
+++ b/src/cl-transmission.lisp
@@ -249,7 +249,7 @@ This function will return nothing of value."
                 all-keys
                 :test 'equal
                 :convert-key ^(gethash % +transmission-set-params+))))
-    (sethash (gethash :id +transmission-set-params+)
+    (sethash (gethash :ids +transmission-set-params+)
              args
              (if (eql ids :all) #() ids))
     (transmission-request conn


### PR DESCRIPTION
Fix bug that ALL torrents were affected in 'cl-transmission:transmission-set' operation regardless of 'ids' parameter.
